### PR TITLE
disable build opusurl library by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 
-option(BUILD_OPUSURL "Build opusurl library" ON)
+option(BUILD_OPUSURL "Build opusurl library" OFF)
 
 option(HUNTER_ENABLED "Enable Hunter package manager" OFF)
 


### PR DESCRIPTION
@rbsheth  need a new release to mitigate problem with cached one https://github.com/cpp-pm/hunter/issues/421